### PR TITLE
🐛 Fix SPA hosting

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"tsc": "tsc --build",
 		"——————————————————————————— vite ———————————————————————————": "",
 		"vite": "vite build",
-		"postvite": "shx cp artifacts/dist/index.html website/dist/404.html",
+		"postvite": "shx cp artifacts/dist/index.html artifacts/dist/404.html",
 		"—————————————————————————— vitest ——————————————————————————": "",
 		"vitest": "vitest run --coverage",
 		"—————————————————————— Custom scripts ——————————————————————": "",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"tsc": "tsc --build",
 		"——————————————————————————— vite ———————————————————————————": "",
 		"vite": "vite build",
+		"postvite": "shx cp artifacts/dist/index.html website/dist/404.html",
 		"—————————————————————————— vitest ——————————————————————————": "",
 		"vitest": "vitest run --coverage",
 		"—————————————————————— Custom scripts ——————————————————————": "",


### PR DESCRIPTION
Fixes GitHub Pages SPA hosting (use same `index.html` file for `404.html` fallback page).