### PR TITLE
🚧 Tweak doc generation

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -2,8 +2,7 @@
 	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
 	// https://biomejs.dev/reference/configuration/
 	"files": {
-		"ignoreUnknown": true,
-		"ignore": ["generated-src"]
+		"ignoreUnknown": true
 	},
 	"vcs": {
 		"enabled": true,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"—————————————————————————— vitest ——————————————————————————": "",
 		"vitest": "vitest run --coverage",
 		"—————————————————————— Custom scripts ——————————————————————": "",
-		"kendo-docs": "tsx tools/kendo-docs/main.ts"
+		"kendo-docs": "tsx tools/kendo-docs/main.ts",
+		"postkendo-docs": "biome format --write --vcs-use-ignore-file=false website/generated-src/kendo-docs"
 	},
 	"dependencies": {
 		"@progress/kendo-licensing": "^1.3.5",

--- a/tools/kendo-docs/main.ts
+++ b/tools/kendo-docs/main.ts
@@ -17,22 +17,19 @@ const destinationRoot = path.join(
 	"kendo-docs",
 );
 
-// Create a project with no configuration
-const project = new Project();
+// Create an empty project
+const project = new Project({
+	skipAddingFilesFromTsConfig: true,
+});
 
 // Add our Kendo packages.
-const moduleNames = ["indicators"];
+const moduleNames = ["kendo-react-indicators"];
 const sourceFiles = moduleNames.map(
 	(moduleName) =>
 		[
 			moduleName,
 			project.addSourceFileAtPath(
-				path.join(
-					nodeModulesRoot,
-					"@progress",
-					`kendo-react-${moduleName}`,
-					"index.d.mts",
-				),
+				path.join(nodeModulesRoot, "@progress", moduleName, "index.d.mts"),
 			),
 		] as const,
 );
@@ -40,7 +37,7 @@ const sourceFiles = moduleNames.map(
 // Process each file
 const documentationDictionaries = sourceFiles.map(
 	([moduleName, sourceFile]) =>
-		[moduleName, processSourceFile(sourceFile)] as const,
+		[moduleName, processSourceFile(sourceFile, moduleName)] as const,
 );
 
 // Write each file
@@ -48,7 +45,7 @@ await Promise.all(
 	documentationDictionaries.map(([moduleName, documentationDictionary]) =>
 		writeDocumentationModel(
 			project,
-			path.join(destinationRoot, `${moduleName}.js`),
+			path.join(destinationRoot, `${moduleName}.ts`),
 			documentationDictionary,
 		),
 	),

--- a/tools/kendo-docs/process-module.ts
+++ b/tools/kendo-docs/process-module.ts
@@ -8,11 +8,12 @@ import { isTypeNode } from "./types.ts";
  */
 export function processSourceFile(
 	sourceFile: SourceFile,
+	moduleName: string,
 ): DocumentationDictionary {
 	const exports: DocumentationDictionary = {};
 	sourceFile.forEachDescendant((node) => {
 		if (isTypeNode(node)) {
-			exports[node.getName()] = translateType(node);
+			exports[node.getName()] = translateType(node, moduleName);
 		}
 	});
 	return exports;

--- a/tools/kendo-docs/write-documentation-model.ts
+++ b/tools/kendo-docs/write-documentation-model.ts
@@ -9,11 +9,11 @@ export function writeDocumentationModel(
 ): Promise<void> {
 	const file = project.createSourceFile(pathToWrite, "", {
 		overwrite: true,
-		scriptKind: ts.ScriptKind.JS,
+		scriptKind: ts.ScriptKind.TS,
 	});
 
 	file.addExportAssignment({
-		// Stringify with no spaces. If you want to examine the output, you can format it in your IDE.
+		// Just stringify it. The `post` script will format. The bundler will minify.
 		expression: JSON.stringify(documentationDictionary),
 		isExportEquals: false, // export default because we lazy import
 	});

--- a/website/src/components/component-page.tsx
+++ b/website/src/components/component-page.tsx
@@ -1,3 +1,5 @@
+/* c8 ignore start -- I will add unit tests once the code settles. */
+
 import {
 	Card,
 	CardBody,
@@ -6,8 +8,6 @@ import {
 	StackLayout,
 } from "@progress/kendo-react-layout";
 import type { JSX } from "react";
-
-/* c8 ignore start -- I will add unit tests once the code settles. */
 
 export type ComponentsPageProps = {
 	componentName: string;

--- a/website/src/components/component-page.tsx
+++ b/website/src/components/component-page.tsx
@@ -1,4 +1,3 @@
-/* c8 ignore start -- I will add unit tests once the code settles. */
 import {
 	Card,
 	CardBody,
@@ -7,6 +6,8 @@ import {
 	StackLayout,
 } from "@progress/kendo-react-layout";
 import type { JSX } from "react";
+
+/* c8 ignore start -- I will add unit tests once the code settles. */
 
 export type ComponentsPageProps = {
 	componentName: string;
@@ -35,11 +36,11 @@ export function ComponentPage(props: Readonly<ComponentsPageProps>) {
 						<pre>
 							<code>{JSON.stringify(props.documentation, null, 2)}</code>
 						</pre>
-						)
 					</CardBody>
 				</Card>
 			</StackLayout>
 		</section>
 	);
 }
+
 /* c8 ignore stop -- END */

--- a/website/src/routes/components_.loader.tsx
+++ b/website/src/routes/components_.loader.tsx
@@ -1,13 +1,12 @@
 import { Loader } from "@progress/kendo-react-indicators";
 import { ComponentPage } from "~/components/component-page.tsx";
-// @ts-expect-error -- No typing for JS dynamic import.
-import indicators from "~/kendo-docs/indicators.js";
+import documentation from "~/kendo-docs/kendo-react-indicators.ts";
 
 export default function LoaderPage() {
 	return (
 		<ComponentPage
 			componentName="Loader"
-			documentation={indicators}
+			documentation={documentation}
 			example={<Loader />}
 		/>
 	);


### PR DESCRIPTION
Tweaks documentation generation to create TypeScript file instead of JS. Generation formats the files as a post step. Remove import expression from "self imports."